### PR TITLE
feat: private dns zone vnet link name override

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,10 +92,11 @@ map(object({
       private_link_private_dns_zones = optional(map(object({
         zone_name = optional(string, null)
       })))
-      auto_registration_zone_enabled = optional(bool, false)
-      auto_registration_zone_name    = optional(string, null)
-      subnet_address_prefix          = string
-      subnet_name                    = optional(string, "dns-resolver")
+      private_dns_zone_network_link_name_template = optional(string)
+      auto_registration_zone_enabled              = optional(bool, false)
+      auto_registration_zone_name                 = optional(string, null)
+      subnet_address_prefix                       = string
+      subnet_name                                 = optional(string, "dns-resolver")
       private_dns_resolver = object({
         enabled             = optional(bool, true)
         name                = string
@@ -211,7 +212,7 @@ Version: 0.3.3
 
 Source: Azure/avm-ptn-network-private-link-private-dns-zones/azurerm
 
-Version: 0.11.0
+Version: 0.12.0
 
 ### <a name="module_virtual_network_side_car"></a> [virtual\_network\_side\_car](#module\_virtual\_network\_side\_car)
 

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ Version: 0.3.3
 
 Source: Azure/avm-ptn-network-private-link-private-dns-zones/azurerm
 
-Version: 0.12.0
+Version: 0.13.0
 
 ### <a name="module_virtual_network_side_car"></a> [virtual\_network\_side\_car](#module\_virtual\_network\_side\_car)
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,17 @@ map(object({
       is_primary          = optional(bool, false)
       private_link_private_dns_zones = optional(map(object({
         zone_name = optional(string, null)
+        custom_iterator = optional(object({
+          replacement_placeholder = string
+          replacement_values      = map(string)
+        }))
+      })))
+      private_link_private_dns_zones_additional = optional(map(object({
+        zone_name = optional(string, null)
+        custom_iterator = optional(object({
+          replacement_placeholder = string
+          replacement_values      = map(string)
+        }))
       })))
       private_dns_zone_network_link_name_template = optional(string)
       auto_registration_zone_enabled              = optional(bool, false)

--- a/examples/full-multi-region/pre.sh
+++ b/examples/full-multi-region/pre.sh
@@ -3,5 +3,5 @@ curl -o test.auto.tfvars https://raw.githubusercontent.com/Azure/alz-terraform-a
 echo "File downloaded successfully."
 echo "Adding randomness to the resource group names..."
 randomness=$(echo $RANDOM | md5sum | head -c 4)
-sed -i "s/rg-/rg-$randomness/g" test.auto.tfvars
+sed -i "s/rg-/rg-$randomness-/g" test.auto.tfvars
 echo "Randomness added to the resource group names."

--- a/examples/full-multi-region/pre.sh
+++ b/examples/full-multi-region/pre.sh
@@ -1,3 +1,7 @@
 echo "Downloading and creating the test.auto.tfvars file from https://raw.githubusercontent.com/Azure/alz-terraform-accelerator/refs/heads/main/templates/platform_landing_zone/examples/full-multi-region/virtual-wan.tfvars..."
 curl -o test.auto.tfvars https://raw.githubusercontent.com/Azure/alz-terraform-accelerator/refs/heads/main/templates/platform_landing_zone/examples/full-multi-region/virtual-wan.tfvars
 echo "File downloaded successfully."
+echo "Adding randomness to the resource group names..."
+randomness=$(echo $RANDOM | md5sum | head -c 4)
+sed -i "s/rg-/rg-$randomness/g" test.auto.tfvars
+echo "Randomness added to the resource group names."

--- a/locals.dns.tf
+++ b/locals.dns.tf
@@ -32,7 +32,8 @@ locals {
   }
   private_dns_zones_virtual_network_links = {
     for key, value in module.virtual_network_side_car : key => {
-      vnet_resource_id = value.resource_id
+      vnet_resource_id                            = value.resource_id
+      virtual_network_link_name_template_override = try(var.virtual_hubs[key].private_dns_zones.private_dns_zone_network_link_name_template, null)
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -82,7 +82,7 @@ module "dns_resolver" {
 
 module "private_dns_zones" {
   source   = "Azure/avm-ptn-network-private-link-private-dns-zones/azurerm"
-  version  = "0.12.0"
+  version  = "0.13.0"
   for_each = local.private_dns_zones
 
   location                                = each.value.location

--- a/main.tf
+++ b/main.tf
@@ -82,7 +82,7 @@ module "dns_resolver" {
 
 module "private_dns_zones" {
   source   = "Azure/avm-ptn-network-private-link-private-dns-zones/azurerm"
-  version  = "0.11.0"
+  version  = "0.12.0"
   for_each = local.private_dns_zones
 
   location                                = each.value.location

--- a/main.tf
+++ b/main.tf
@@ -85,13 +85,14 @@ module "private_dns_zones" {
   version  = "0.13.0"
   for_each = local.private_dns_zones
 
-  location                                = each.value.location
-  resource_group_name                     = each.value.resource_group_name
-  enable_telemetry                        = var.enable_telemetry
-  private_link_private_dns_zones          = each.value.private_link_private_dns_zones == null ? (each.value.is_primary ? null : local.private_dns_zones_secondary_zones) : each.value.private_link_private_dns_zones
-  resource_group_creation_enabled         = false
-  tags                                    = var.tags
-  virtual_network_resource_ids_to_link_to = local.private_dns_zones_virtual_network_links
+  location                                  = each.value.location
+  resource_group_name                       = each.value.resource_group_name
+  enable_telemetry                          = var.enable_telemetry
+  private_link_private_dns_zones            = each.value.private_link_private_dns_zones == null ? (each.value.is_primary ? null : local.private_dns_zones_secondary_zones) : each.value.private_link_private_dns_zones
+  private_link_private_dns_zones_additional = try(each.value.private_link_private_dns_zones_additional, null)
+  resource_group_creation_enabled           = false
+  tags                                      = var.tags
+  virtual_network_resource_ids_to_link_to   = local.private_dns_zones_virtual_network_links
 }
 
 module "private_dns_zone_auto_registration" {

--- a/variables.tf
+++ b/variables.tf
@@ -36,6 +36,17 @@ variable "virtual_hubs" {
       is_primary          = optional(bool, false)
       private_link_private_dns_zones = optional(map(object({
         zone_name = optional(string, null)
+        custom_iterator = optional(object({
+          replacement_placeholder = string
+          replacement_values      = map(string)
+        }))
+      })))
+      private_link_private_dns_zones_additional = optional(map(object({
+        zone_name = optional(string, null)
+        custom_iterator = optional(object({
+          replacement_placeholder = string
+          replacement_values      = map(string)
+        }))
       })))
       private_dns_zone_network_link_name_template = optional(string)
       auto_registration_zone_enabled              = optional(bool, false)

--- a/variables.tf
+++ b/variables.tf
@@ -37,10 +37,11 @@ variable "virtual_hubs" {
       private_link_private_dns_zones = optional(map(object({
         zone_name = optional(string, null)
       })))
-      auto_registration_zone_enabled = optional(bool, false)
-      auto_registration_zone_name    = optional(string, null)
-      subnet_address_prefix          = string
-      subnet_name                    = optional(string, "dns-resolver")
+      private_dns_zone_network_link_name_template = optional(string)
+      auto_registration_zone_enabled              = optional(bool, false)
+      auto_registration_zone_name                 = optional(string, null)
+      subnet_address_prefix                       = string
+      subnet_name                                 = optional(string, "dns-resolver")
       private_dns_resolver = object({
         enabled             = optional(bool, true)
         name                = string


### PR DESCRIPTION
## Description

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #456
-->

Add the ability to override the vnet link name for DNS zones. This is primarily for migration purposes.

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [x] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
