### PR TITLE
fix: vwan hub sku and sidecar vnet link

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ Version: 0.8.1
 
 Source: Azure/avm-ptn-virtualwan/azurerm
 
-Version: 0.12.1
+Version: 0.12.2
 
 <!-- markdownlint-disable-next-line MD041 -->
 ## Data Collection

--- a/examples/full-multi-region/test.auto.tfvars
+++ b/examples/full-multi-region/test.auto.tfvars
@@ -54,7 +54,7 @@ custom_replacements = {
     primary_virtual_network_gateway_vpn_enabled           = true
     primary_private_dns_zones_enabled                     = true
     primary_private_dns_auto_registration_zone_enabled    = true
-    primary_private_dns_resolver_enabled                  = true # This setting currently has no effect, but will be implemented in a future release. To turn off the private DNS resolver, set the `primary_private_dns_zones_enabled` setting to `false`.
+    primary_private_dns_resolver_enabled                  = true
     primary_bastion_enabled                               = true
     primary_sidecar_virtual_network_enabled               = true
 
@@ -64,7 +64,7 @@ custom_replacements = {
     secondary_virtual_network_gateway_vpn_enabled           = true
     secondary_private_dns_zones_enabled                     = true
     secondary_private_dns_auto_registration_zone_enabled    = true
-    secondary_private_dns_resolver_enabled                  = true # This setting currently has no effect, but will be implemented in a future release. To turn off the private DNS resolver, set the `secondary_private_dns_zones_enabled` setting to `false`.
+    secondary_private_dns_resolver_enabled                  = true
     secondary_bastion_enabled                               = true
     secondary_sidecar_virtual_network_enabled               = true
 
@@ -244,6 +244,13 @@ management_group_settings = {
         }
       }
     }
+    landingzones = {
+      policy_assignments = {
+        Enable-DDoS-VNET = {
+          enforcement_mode = "DoNotEnforce"
+        }
+      }
+    }
     */
     /*
     # Example of how to update a policy assignment enforcement mode for Private Link DNS Zones
@@ -362,7 +369,7 @@ virtual_wan_virtual_hubs = {
       dns_zones = {
         resource_group_name = "$${dns_resource_group_name}"
         private_link_private_dns_zones_regex_filter = {
-          enabled = true
+          enabled = false
         }
       }
       auto_registration_zone_enabled = "$${primary_private_dns_auto_registration_zone_enabled}"
@@ -430,7 +437,7 @@ virtual_wan_virtual_hubs = {
       dns_zones = {
         resource_group_name = "$${dns_resource_group_name}"
         private_link_private_dns_zones_regex_filter = {
-          enabled = false
+          enabled = true
         }
       }
       auto_registration_zone_enabled = "$${secondary_private_dns_auto_registration_zone_enabled}"

--- a/locals.virtual.network.tf
+++ b/locals.virtual.network.tf
@@ -56,10 +56,11 @@ locals {
     remote_virtual_network_id = virtual_network_connection.remote_virtual_network_id
     settings                  = virtual_network_connection.settings
   } }
-  virtual_network_connections_side_car = { for key, value in local.private_dns_zones : "private_dns_vnet_${key}" => {
-    name                      = "private_dns_vnet_${key}"
+  virtual_network_connections_side_car = { for key, value in local.side_car_virtual_networks : "private_dns_vnet_${key}" => {
+    name                      = try(var.virtual_hubs[key].side_car_virtual_network.virtual_network_connection_name, "vnet-side-car-${key}")
     virtual_hub_key           = key
     remote_virtual_network_id = module.virtual_network_side_car[key].resource_id
+    settings                  = try(var.virtual_hubs[key].side_car_virtual_network.virtual_network_connection_settings, null)
     } if local.side_car_virtual_networks_enabled[key]
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -19,7 +19,7 @@ module "firewall_policy" {
 
 module "virtual_wan" {
   source  = "Azure/avm-ptn-virtualwan/azurerm"
-  version = "0.12.1"
+  version = "0.12.2"
 
   location                              = var.virtual_wan_settings.location
   resource_group_name                   = var.virtual_wan_settings.resource_group_name


### PR DESCRIPTION
## Description

Fix to workaround a bug in the azurerm provider for vwan hub sku handling.

Fix to remove the coupling of sidecar vnet link to private dns zone deployment.

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #456
-->

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
