### PR TITLE
fix: bastion and dns resolver require sidecar

### DIFF
--- a/locals.bastion.tf
+++ b/locals.bastion.tf
@@ -19,6 +19,6 @@ locals {
         public_ip_address_id = module.bastion_public_ip[key].public_ip_id
         create_public_ip     = false
       }
-    }, value.bastion.bastion_host) if local.bastions_enabled[key]
+    }, value.bastion.bastion_host) if local.bastions_enabled[key] && local.side_car_virtual_networks_enabled[key]
   }
 }

--- a/locals.dns_resolver.tf
+++ b/locals.dns_resolver.tf
@@ -12,5 +12,5 @@ locals {
         subnet_name = module.virtual_network_side_car[key].subnets["dns_resolver"].name
       }
     } : {}
-  }, value.private_dns_resolver.dns_resolver) if local.private_dns_resolver_enabled[key] }
+  }, value.private_dns_resolver.dns_resolver) if local.private_dns_resolver_enabled[key] && local.side_car_virtual_networks_enabled[key] }
 }


### PR DESCRIPTION
## Description

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #456
-->

Side car vnet must be enabled for bastion and dns resolver

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [ ] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [x] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
