### PR TITLE
fix: auto registration zone depends on sidecar

### DIFF
--- a/locals.dns.tf
+++ b/locals.dns.tf
@@ -11,7 +11,7 @@ locals {
     location            = value.hub.location
     resource_group_name = value.hub.resource_group
     vnet_resource_id    = module.virtual_network_side_car[key].resource_id
-  }, value.private_dns_zones) if local.private_dns_zones_enabled[key] && try(value.private_dns_zones.auto_registration_zone_enabled, false) }
+  }, value.private_dns_zones) if local.private_dns_zones_enabled[key] && local.side_car_virtual_networks_enabled[key] && try(value.private_dns_zones.auto_registration_zone_enabled, false) }
   private_dns_zones_virtual_network_links = {
     for key, value in module.virtual_network_side_car : key => {
       vnet_resource_id                            = value.resource_id


### PR DESCRIPTION
## Description

PRivate DNS auto registration zone is dependent on side car vnet, so switch it off if not there

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #456
-->

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
