### PR TITLE
fix: firewall dns setting dependent on sidecar

### DIFF
--- a/locals.bastion.tf
+++ b/locals.bastion.tf
@@ -1,5 +1,5 @@
 locals {
-  bastions_enabled = { for key, value in var.virtual_hubs : key => try(value.bastion.enabled, try(value.bastion, null) != null) }
+  bastions_enabled = { for key, value in var.virtual_hubs : key => try(value.bastion.enabled, try(value.bastion, null) != null) && local.side_car_virtual_networks_enabled[key] }
 }
 
 locals {
@@ -19,6 +19,6 @@ locals {
         public_ip_address_id = module.bastion_public_ip[key].public_ip_id
         create_public_ip     = false
       }
-    }, value.bastion.bastion_host) if local.bastions_enabled[key] && local.side_car_virtual_networks_enabled[key]
+    }, value.bastion.bastion_host) if local.bastions_enabled[key]
   }
 }

--- a/locals.dns.tf
+++ b/locals.dns.tf
@@ -10,8 +10,15 @@ locals {
   private_dns_zones_auto_registration = { for key, value in var.virtual_hubs : key => merge({
     location            = value.hub.location
     resource_group_name = value.hub.resource_group
-    vnet_resource_id    = module.virtual_network_side_car[key].resource_id
-  }, value.private_dns_zones) if local.private_dns_zones_enabled[key] && local.side_car_virtual_networks_enabled[key] && try(value.private_dns_zones.auto_registration_zone_enabled, false) }
+  }, value.private_dns_zones) if local.private_dns_zones_enabled[key] && try(value.private_dns_zones.auto_registration_zone_enabled, false) }
+  private_dns_zones_auto_registration_virtual_network_links = {
+    for key, value in module.virtual_network_side_car : key => {
+      vnetlinkname     = "vnet-link-${each.key}-auto-registration"
+      vnetid           = value.resource_id
+      autoregistration = true
+      tags             = var.tags
+    }
+  }
   private_dns_zones_virtual_network_links = {
     for key, value in module.virtual_network_side_car : key => {
       vnet_resource_id                            = value.resource_id

--- a/locals.dns_resolver.tf
+++ b/locals.dns_resolver.tf
@@ -1,5 +1,5 @@
 locals {
-  private_dns_resolver_enabled = { for key, value in var.virtual_hubs : key => try(value.private_dns_resolver.enabled, try(value.private_dns_resolver, null) != null) }
+  private_dns_resolver_enabled = { for key, value in var.virtual_hubs : key => try(value.private_dns_resolver.enabled, try(value.private_dns_resolver, null) != null) && local.side_car_virtual_networks_enabled[key] }
 }
 
 locals {
@@ -12,5 +12,5 @@ locals {
         subnet_name = module.virtual_network_side_car[key].subnets["dns_resolver"].name
       }
     } : {}
-  }, value.private_dns_resolver.dns_resolver) if local.private_dns_resolver_enabled[key] && local.side_car_virtual_networks_enabled[key] }
+  }, value.private_dns_resolver.dns_resolver) if local.private_dns_resolver_enabled[key] }
 }

--- a/main.tf
+++ b/main.tf
@@ -105,18 +105,11 @@ module "private_dns_zone_auto_registration" {
   version  = "0.3.3"
   for_each = local.private_dns_zones_auto_registration
 
-  domain_name         = each.value.auto_registration_zone_name
-  resource_group_name = each.value.resource_group_name
-  enable_telemetry    = var.enable_telemetry
-  tags                = var.tags
-  virtual_network_links = {
-    auto_registration = {
-      vnetlinkname     = "vnet-link-${each.key}-auto-registration"
-      vnetid           = each.value.vnet_resource_id
-      autoregistration = true
-      tags             = var.tags
-    }
-  }
+  domain_name           = each.value.auto_registration_zone_name
+  resource_group_name   = each.value.resource_group_name
+  enable_telemetry      = var.enable_telemetry
+  tags                  = var.tags
+  virtual_network_links = local.private_dns_zones_auto_registration_virtual_network_links
 }
 
 module "ddos_protection_plan" {


### PR DESCRIPTION
## Description

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #456
-->

Firewall DNS settings should only be created if sidecar vnet is enabled. This also allows creation of the autoregistration zone without the sidecar vnet for that edge case.

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
