### PR TITLE
fix: typo in map key

### DIFF
--- a/locals.dns.tf
+++ b/locals.dns.tf
@@ -12,7 +12,7 @@ locals {
     domain_name         = value.private_dns_zones.auto_registration_zone_name
     resource_group_name = try(value.auto_registration_zone_resource_group_name, local.private_dns_zones[key].resource_group_name)
     virtual_network_links = local.side_car_virtual_networks_enabled[key] ? {
-      auto_registion = {
+      auto_registration = {
         vnetlinkname     = "vnet-link-${key}-auto-registration"
         vnetid           = module.virtual_network_side_car[key].resource_id
         autoregistration = true


### PR DESCRIPTION
## Description

Fix typo in map key name causing a destroy and create

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #456
-->

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [x] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
