### PR TITLE
✨ Add branch-to-branch traffic configuration to virtual hub

### DIFF
--- a/modules/virtual-hub/main.tf
+++ b/modules/virtual-hub/main.tf
@@ -11,4 +11,5 @@ resource "azurerm_virtual_hub" "virtual_hub" {
   tags                                   = each.value.tags
   virtual_router_auto_scale_min_capacity = each.value.virtual_router_auto_scale_min_capacity
   virtual_wan_id                         = each.value.virtual_wan_id
+  branch_to_branch_traffic_enabled       = each.value.branch_to_branch_traffic_enabled
 }

--- a/modules/virtual-hub/variables.tf
+++ b/modules/virtual-hub/variables.tf
@@ -9,6 +9,7 @@ variable "virtual_hubs" {
     hub_routing_preference                 = optional(string, "ExpressRoute")
     virtual_router_auto_scale_min_capacity = optional(number, 2)
     sku                                    = optional(string, null)
+    branch_to_branch_traffic_enabled       = optional(bool, false)
   }))
   default     = {}
   description = <<DESCRIPTION
@@ -23,6 +24,8 @@ variable "virtual_hubs" {
   - `tags`: Optional tags to apply to the Virtual Hub resource.
   - `hub_routing_preference`: Optional hub routing preference for the Virtual Hub. Possible values are: `ExpressRoute`, `ASPath`, `VpnGateway`. Defaults to `ExpressRoute`. See https://learn.microsoft.com/azure/virtual-wan/hub-settings#routing-preference for more information.
   - `virtual_router_auto_scale_min_capacity`: Optional minimum capacity for the Virtual Router auto scale. Defaults to `2`. See https://learn.microsoft.com/azure/virtual-wan/hub-settings#capacity for more information.
+  - `sku`: Optional The SKU of the Virtual Hub. Possible values are Basic and Standard. Changing this forces a new resource to be created.
+  - `branch_to_branch_traffic_enabled`: Optional Boolean flag to specify whether branch to branch traffic is allowed. Defaults to false
 
   > Note: There can be multiple objects in this map, one for each Virtual Hub you wish to deploy into the Virtual WAN. Multiple Virtual Hubs in the same region/location can be deployed into the same Virtual WAN also.
 


### PR DESCRIPTION

## Description

[AVM Module Issue]: virtual-hub is missing the branch_to_branch_traffic_enabled parameter Fixes Azure/Azure-Landing-Zones#354 

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [x] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
