### PR TITLE
restore sidecar subnet service_endpoints via VNet module v0.20.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1395,7 +1395,7 @@ Version: 0.1.0
 
 Source: Azure/avm-res-network-virtualnetwork/azurerm
 
-Version: 0.15.0
+Version: 0.20.0
 
 ### <a name="module_virtual_network_subnet_ip_prefixes"></a> [virtual\_network\_subnet\_ip\_prefixes](#module\_virtual\_network\_subnet\_ip\_prefixes)
 

--- a/examples/virtual-hub-with-network-connections/README.md
+++ b/examples/virtual-hub-with-network-connections/README.md
@@ -73,7 +73,7 @@ module "resource_group_vnet_demo_01" {
 
 module "virtual_network" {
   source  = "Azure/avm-res-network-virtualnetwork/azurerm"
-  version = "0.15.0"
+  version = "0.20.0"
 
   location      = local.resource_groups["hub_primary"].location
   parent_id     = module.resource_group_vnet_demo_01.resource_id
@@ -193,7 +193,7 @@ Version:
 
 Source: Azure/avm-res-network-virtualnetwork/azurerm
 
-Version: 0.15.0
+Version: 0.20.0
 
 <!-- markdownlint-disable-next-line MD041 -->
 ## Data Collection

--- a/examples/virtual-hub-with-network-connections/main.tf
+++ b/examples/virtual-hub-with-network-connections/main.tf
@@ -66,7 +66,7 @@ module "resource_group_vnet_demo_01" {
 
 module "virtual_network" {
   source  = "Azure/avm-res-network-virtualnetwork/azurerm"
-  version = "0.15.0"
+  version = "0.20.0"
 
   location      = local.resource_groups["hub_primary"].location
   parent_id     = module.resource_group_vnet_demo_01.resource_id

--- a/main.tf
+++ b/main.tf
@@ -60,7 +60,7 @@ moved {
 
 module "virtual_network_side_car" {
   source   = "Azure/avm-res-network-virtualnetwork/azurerm"
-  version  = "0.15.0"
+  version  = "0.20.0"
   for_each = local.sidecar_virtual_networks
 
   location             = each.value.location


### PR DESCRIPTION
The sidecar virtual network pinned avm-res-network-virtualnetwork v0.15.0, which falls in the v0.15.0–v0.19.0 range that dropped the names-only `service_endpoints` attribute from its subnet object type. Because the module passes the full subnet object to the VNet module, Terraform silently discarded `service_endpoints` during object type conversion, so requested endpoints never reached the Azure payload — omitted on create, and removed as `serviceEndpoints -> null` on upgrade.

Bump the sidecar VNet dependency to v0.20.0, which restores the names-only `service_endpoints` input (VNet PR #130). The public sidecar contract is already names-only, so no schema migration is required. The standalone VNet in the virtual-hub-with-network-connections example is aligned to v0.20.0 for consistency, and the generated READMEs are updated.

Contributes to Azure/Azure-Landing-Zones#554
Related Azure/Azure-Landing-Zones#4017

## Description

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #456
-->

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
