### PR TITLE
feat: expose route_tables on virtual_hubs

### DIFF
--- a/README.md
+++ b/README.md
@@ -707,6 +707,19 @@ map(object({
       }))
     })), {})
 
+    route_tables = optional(map(object({
+      name   = string
+      labels = optional(list(string))
+      routes = optional(map(object({
+        name                = string
+        destinations        = list(string)
+        destinations_type   = string
+        next_hop            = optional(string)
+        vnet_connection_key = optional(string)
+        next_hop_type       = optional(string, "ResourceId")
+      })))
+    })), {})
+
     express_route_circuit_connections = optional(map(object({
       name                                 = string
       express_route_circuit_peering_id     = string

--- a/locals.virtual.network.tf
+++ b/locals.virtual.network.tf
@@ -69,3 +69,20 @@ locals {
     } if local.sidecar_virtual_networks_enabled[key]
   }
 }
+
+locals {
+  virtual_hub_route_tables = { for route_table in flatten([for virtual_hub_key, virtual_hub_value in var.virtual_hubs :
+    [for route_table_key, route_table_value in virtual_hub_value.route_tables : {
+      unique_key      = "${virtual_hub_key}-${route_table_key}"
+      name            = route_table_value.name
+      virtual_hub_key = virtual_hub_key
+      labels          = route_table_value.labels
+      routes          = route_table_value.routes
+    }]
+    ]) : route_table.unique_key => {
+    name            = route_table.name
+    virtual_hub_key = route_table.virtual_hub_key
+    labels          = route_table.labels
+    routes          = route_table.routes
+  } }
+}

--- a/main.tf
+++ b/main.tf
@@ -44,6 +44,7 @@ module "virtual_wan" {
   routing_intents                       = local.routing_intents
   tags                                  = var.tags
   type                                  = local.virtual_wan.type
+  virtual_hub_route_tables              = local.virtual_hub_route_tables
   virtual_hubs                          = local.virtual_hubs
   virtual_network_connections           = local.virtual_network_connections
   virtual_wan_id                        = local.virtual_wan.id

--- a/variables.tf
+++ b/variables.tf
@@ -184,6 +184,20 @@ variable "virtual_hubs" {
       }))
     })), {})
 
+
+    route_tables = optional(map(object({
+      name   = string
+      labels = optional(list(string))
+      routes = optional(map(object({
+        name                = string
+        destinations        = list(string)
+        destinations_type   = string
+        next_hop            = optional(string)
+        vnet_connection_key = optional(string)
+        next_hop_type       = optional(string, "ResourceId")
+      })))
+    })), {})
+
     express_route_circuit_connections = optional(map(object({
       name                                 = string
       express_route_circuit_peering_id     = string


### PR DESCRIPTION
## Description

Fixes the missing `route_tables` support on Virtual WAN hubs.

The `virtual-wan` submodule already implements `azurerm_virtual_hub_route_table` via its `virtual_hub_route_tables` variable, but the root module's `virtual_hubs` object never exposed a `route_tables` field, and no flatten/passthrough existed to forward it to the submodule. Consumers configuring `route_tables` in their `virtual_hubs` input got **no error and no resource** — Terraform silently drops undeclared keys from `object()` types during `.tfvars` conversion, so the gap was completely invisible.

Related to Azure/Azure-Landing-Zones#4193

## Type of Change

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
  - [x] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks (`avm pre-commit` — all 5 steps pass: sync, check convention, transform, format, docs)

**Validation evidence:**
- `terraform plan` — clean, `azurerm_virtual_hub_route_table` shown as resource to add, no errors
- `terraform apply` — resource created successfully against a real Virtual WAN hub
- `az network vhub route-table show` — confirms `provisioningState: Succeeded` on the live Azure resource

```json
{
  "name": "rt-issue4193",
  "type": "Microsoft.Network/virtualHubs/hubRouteTables",
  "provisioningState": "Succeeded",
  "routes": [
    {
      "name": "to-firewall",
      "destinations": ["0.0.0.0/0"],
      "destinationType": "CIDR",
      "nextHop": "<azure-firewall-resource-id>",
      "nextHopType": "ResourceId"
    }
  ]
}
```
